### PR TITLE
Extend mysql timeout

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,10 @@ services:
       - ./dbdata:/var/lib/mysql
     networks:
       - A
+    command: [
+            '--wait_timeout=28800',
+            '--interactive_timeout=28800'
+        ]
 
   mlflow:
     restart: always


### PR DESCRIPTION
Long running jobs may experience a MySQL timeout. This causes all subsequent logging requests, to the mlflow server, to return HTTP error 500, eventually causing any experiments to fail.

This change extends the MySQL timout in order to minimise the risk of this error occouring.